### PR TITLE
refactor(collect): Simplify collect logic and add auto-collect

### DIFF
--- a/jules.md
+++ b/jules.md
@@ -180,3 +180,22 @@
 - **产出**:
   - `jules/plan016.md`
   - `jules/plan016-report.md`
+
+### 2025-09-07: Refactor Collect Logic and Implement Auto-Collect (Plan 017)
+
+- **目标**: 根据用户反馈，重构 `collect` 接口，简化其逻辑，并实现一个“自动收集”（auto-collect）机制以优化网络交互。
+- **实施**:
+  - **`collect` 方法重构**:
+    - 移除了内部复杂的 `deriveSequence` 逻辑，该方法现在只发送单个 `collect` 请求。
+    - 简化了 `playIndex` 的确定方式：优先使用调用者传入的 `playIndex`；若未传入，则默认为 `lastResultsCount - 1`，即收集最新的一个结果。
+    - 为该方法补充了详尽的 JSDoc 注释，阐明了其功能和参数行为。
+  - **实现 Auto-Collect**:
+    - 在 `spin` 和 `selectOptional` 的 `cmdret` 处理器中增加了新逻辑。
+    - 当一次操作返回多个结果时（`lastResultsCount > 1`），客户端会自动调用 `collect(lastResultsCount - 2)`。
+    - 此操作会将倒数第二个结果确认为“已读”，只留下最后一个结果待玩家手动收集，从而减少了不必要的网络通信。
+    - 自动收集调用被设计为非阻塞的，其错误会被捕获并记录，不会影响主游戏流程。
+  - **测试修复**:
+    - 由于 `collect` 的行为发生根本性改变，重写了所有相关的单元测试和集成测试，以验证新的简化逻辑和自动收集流程。
+- **产出**:
+  - `jules/plan017.md`
+  - `jules/plan017-report.md`

--- a/jules/plan017-report.md
+++ b/jules/plan017-report.md
@@ -1,0 +1,38 @@
+# Plan 017 Report: Refactor Collect Logic and Implement Auto-Collect
+
+## 1. Task Summary
+
+This task involved a significant refactoring of the `collect` method and the introduction of an "auto-collect" mechanism to improve network efficiency and simplify the client-side logic. The original `collect` method was overly complex and contained logic that was difficult to maintain.
+
+## 2. Implementation Details
+
+### a. `collect()` Method Refactoring
+
+- **Removed Complexity**: The `deriveSequence` helper function and the logic for sending multiple `collect` commands in a sequence were completely removed from the `collect` method.
+- **Simplified `playIndex` Logic**: The method now follows a clear, simple rule for determining the `playIndex`:
+  1.  Use the `playIndex` if it's explicitly provided.
+  2.  If not provided, default to `lastResultsCount - 1` (the index of the final result).
+  3.  As a fallback, use the cached `lastPlayIndex` if `lastResultsCount` is unavailable.
+- **Improved Commenting**: Added comprehensive JSDoc comments to the `collect` method explaining its purpose, parameters, and the new logic.
+
+### b. Auto-Collect Implementation
+
+- **Trigger**: An auto-collect mechanism was added to the `cmdret` handler for the `gamectrl3` command (used by `spin` and `selectOptional`).
+- **Logic**: After a `spin` or `selectOptional` completes, the client checks if the number of results (`lastResultsCount`) is greater than 1.
+  - If it is, the client automatically calls `this.collect()` with a `playIndex` of `lastResultsCount - 2`.
+- **Purpose**: This action confirms all but the final result with the server in the background, reducing the number of explicit `collect` calls the user-facing application needs to make.
+- **Error Handling**: The auto-collect call is wrapped in a `.catch()` block that logs any errors but does not let them propagate. This ensures that a failure in this background optimization does not disrupt the primary game flow.
+- **Commenting**: Added comments in the `handleMessage` method to explain the auto-collect feature.
+
+## 3. Verification and Testing
+
+- The initial changes caused several tests to fail, as they were written to validate the old, more complex `collect` behavior.
+- The following tests were updated:
+  - `tests/main.test.ts`: Updated an expected error message to match the more descriptive message in the new implementation.
+  - `tests/main-adv.test.ts`: Replaced an obsolete test for sequential collection with a new test that specifically validates the auto-collect logic.
+  - `tests/integration.test.ts`: Rewrote the entire `Collect Flow` test suite. The new tests verify the auto-collect behavior in one case and test the manual collect failure path in another by ensuring auto-collect does not trigger (`resultsCount: 1`).
+- After fixing the tests, `npm run check` was executed, and all tests, linting, and build steps passed successfully.
+
+## 4. Conclusion
+
+The `collect` logic is now simpler, more aligned with the project's requirements, and easier to maintain. The new auto-collect feature will improve the efficiency of the network protocol by reducing round-trips for multi-stage wins. The code is well-commented and the test suite has been updated to reflect the new, correct behavior.

--- a/jules/plan017.md
+++ b/jules/plan017.md
@@ -1,0 +1,43 @@
+# Plan 017: Refactor Collect Logic and Implement Auto-Collect
+
+## 1. Goal
+
+The primary goal is to refactor the `collect` method in `SlotcraftClient` to simplify its logic and implement an "auto-collect" feature to improve efficiency by reducing client-server communication. This involves updating the core logic, adding extensive comments, and ensuring all related documentation is updated.
+
+## 2. Understanding the Requirements
+
+Based on the user's request, the current `collect` implementation is unnecessarily complex and doesn't align with the desired protocol flow.
+
+- **`collect` Simplification**: The current `collect` method has a complex `deriveSequence` helper that attempts to determine which `playIndex` to use. The user has clarified that if a `playIndex` is not explicitly provided, the client should simply use the index of the last available result, which is `replyPlay.results.length - 1`.
+- **Auto-Collect Feature**: When a `spin` or `selectOptional` action results in multiple outcomes (`replyPlay.results.length > 1`), the client should automatically send a `collect` call for the second-to-last result (`replyPlay.results.length - 2`). This confirms to the server that the user has "seen" all but the final outcome, reducing the need for explicit `collect` calls later. This should be triggered from the `cmdret` handler for `gamectrl3`.
+- **Documentation and Commenting**: The new logic must be thoroughly commented. The project's development documentation (`jules.md`) needs to be updated to reflect these changes.
+
+## 3. Task Breakdown
+
+1.  **Create Plan File**: Create `jules/plan017.md` to document the plan. (This step)
+2.  **Refactor `collect` Method (`src/main.ts`)**:
+    -   Remove the internal `deriveSequence` function.
+    -   Modify the logic to determine `playIndex`:
+        -   If `playIndex` is passed as an argument, use it.
+        -   If `playIndex` is `undefined`, use `this.userInfo.lastResultsCount - 1`.
+        -   As a fallback, if `lastResultsCount` is not available, use `this.userInfo.lastPlayIndex`.
+    -   Remove the sequential collect loop, as the method should only send a single `collect` command per call.
+    -   Add detailed comments explaining the new, simplified logic and the purpose of the `collect` flow.
+
+3.  **Implement Auto-Collect (`src/main.ts`)**:
+    -   Locate the `cmdret` handler for the `gamectrl3` command within the `handleMessage` method.
+    -   After the existing state transitions (`SPINEND`, `WAITTING_PLAYER`, etc.), add a new block of code.
+    -   Inside this block, check if `this.userInfo.lastResultsCount` is greater than 1.
+    -   If it is, call `this.collect(this.userInfo.lastResultsCount - 2)`.
+    -   This call should be non-blocking. Use a `.catch()` block to log any potential errors without affecting the main application flow.
+    -   Add comments to explain the auto-collect mechanism, why it's there, and how it works.
+
+4.  **Verify Changes**:
+    -   Run `npm install` to ensure all dependencies are correctly installed.
+    -   Run `npm run check` to execute linting, tests, and build to ensure the changes are correct and have not introduced any regressions.
+    -   If tests fail due to the changed `collect` behavior, update the relevant test cases in `tests/integration.test.ts` or `tests/main.test.ts` to reflect the new, correct logic.
+
+5.  **Update Documentation**:
+    -   Create a final report `jules/plan017-report.md` summarizing the work done.
+    -   Update `jules.md` to document the new `collect` and auto-collect logic in the development log section.
+    -   Review `agents.md` to determine if any instructions need to be updated for future agent interactions. Given the nature of the change, it's likely no update will be needed, but it's important to check.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -269,7 +269,9 @@ describe('SlotcraftClient (Real Timers)', () => {
       (client as any).userInfo.lastPlayIndex = undefined;
       (client as any).userInfo.lastResultsCount = undefined;
 
-      await expect(client.collect()).rejects.toThrow('playIndex not available');
+      await expect(client.collect()).rejects.toThrow(
+        'playIndex is not available and could not be derived.'
+      );
     });
 
     it('should correctly parse gamecfg and derive linesOptions', async () => {


### PR DESCRIPTION
Refactored the `collect` method to simplify its implementation. The complex sequential collection logic has been removed. The method now sends a single `collect` command. If `playIndex` is not provided, it defaults to collecting the last result (`lastResultsCount - 1`).

Implemented an "auto-collect" feature that triggers after a `spin` or `selectOptional` command if the response contains multiple results. This feature automatically collects the second-to-last result (`lastResultsCount - 2`) to improve network efficiency.

Updated all relevant tests to match the new behavior and added extensive comments to document the new logic. Updated project documentation.