### PR TITLE
Feature/add constructor params

### DIFF
--- a/jules.md
+++ b/jules.md
@@ -242,16 +242,14 @@
   - `jules/plan020.md`
   - `jules/plan020-report.md`
 
-### 2025-09-08: Enhance Example Script for Resume Logic (Plan 021)
+### 2025-09-08: Simplify Example Script for Clarity (Plan 022)
 
-- **目标**: 改进 `examples/example001.ts` 示例脚本，使其能够正确处理 `enterGame` 后可能出现的各种游戏恢复状态。
+- **目标**: 根据用户反馈，重构 `examples/example001.ts` 示例脚本，简化其游戏恢复逻辑，使其更清晰、更易于理解。
 - **实施**:
-  - **引入游戏循环**: 在示例脚本中实现了一个 `gameLoop` 函数。该函数在 `enterGame` 之后被调用，并负责根据客户端的当前状态 (`SPINEND`, `WAITTING_PLAYER`, `IN_GAME`) 决定下一步操作。
-  - **状态驱动逻辑**:
-    - 如果状态是 `SPINEND`，脚本会自动调用 `client.collect()`。
-    - 如果状态是 `WAITTING_PLAYER`，脚本会自动调用 `client.selectOptional()`。
-    - 只有当状态是 `IN_GAME` 时，脚本才会执行主要的 `spinAcrossLines` 逻辑。
-  - **提升健壮性**: 此修改使示例脚本对游戏恢复流程的处理更加健壮，为开发者提供了更准确、更可靠的用例参考。
+  - **移除游戏循环**: 删除了原有的 `gameLoop` 函数，因为它对一个示例来说过于复杂。
+  - **线性化恢复逻辑**: 在 `enterGame()` 调用之后，直接内联实现了一个简单的 `while` 循环。此循环专门负责处理恢复状态（`SPINEND`, `WAITTING_PLAYER`），直到客户端状态变为 `IN_GAME`。
+  - **增加注释**: 为恢复逻辑和核心的 `spinAcrossLines` 函数调用添加了明确的注释，以阐明脚本的执行流程。
+- **成果**: 最终的示例脚本现在能以一种非常直接和易于理解的方式来演示核心功能，包括如何处理游戏恢复，显著提升了作为教学工具的价值。
 - **产出**:
-  - `jules/plan021.md`
-  - `jules/plan021-report.md`
+  - `jules/plan022.md`
+  - `jules/plan022-report.md`

--- a/jules.md
+++ b/jules.md
@@ -229,3 +229,15 @@
 - **产出**:
   - `jules/plan019.md`
   - `jules/plan019-report.md`
+
+### 2025-09-08: Implement Game Resume Logic (Plan 020)
+
+- **目标**: 实现“游戏恢复”（Resume）功能。当用户 `enterGame` 时，如果服务器返回一个未完成的游戏状态（例如，有待收集的奖励或待做的选择），客户端需要能正确地恢复到该状态。
+- **实施**:
+  - **新增 `RESUMING` 状态**: 在 `ConnectionState` 中加入了 `RESUMING` 状态，用于明确表示客户端正在处理 `comeingame` 的响应。`enterGame` 方法现在会进入此状态。
+  - **`cmdret` 驱动状态恢复**: 核心恢复逻辑被实现在 `comeingame3` 的 `cmdret` 处理器中。此处理器会检查 `gamemoduleinfo` 的内容，并根据 `replyPlay.finished` 和 `totalwin` 等字段，决定将客户端转换到 `WAITTING_PLAYER`、`SPINEND` 还是 `IN_GAME` 状态。这确保了状态转换的原子性和准确性。
+  - **复用 Auto-Collect**: 在恢复流程中，如果检测到有多个待处理结果，会自动复用现有的 `auto-collect` 逻辑来确认中间结果，优化了用户体验。
+  - **补充注释和测试**: 为新的状态和逻辑流程补充了详尽的 JSDoc 注释，并新增了专门的集成测试用例来验证所有恢复场景。
+- **产出**:
+  - `jules/plan020.md`
+  - `jules/plan020-report.md`

--- a/jules.md
+++ b/jules.md
@@ -241,3 +241,17 @@
 - **产出**:
   - `jules/plan020.md`
   - `jules/plan020-report.md`
+
+### 2025-09-08: Enhance Example Script for Resume Logic (Plan 021)
+
+- **目标**: 改进 `examples/example001.ts` 示例脚本，使其能够正确处理 `enterGame` 后可能出现的各种游戏恢复状态。
+- **实施**:
+  - **引入游戏循环**: 在示例脚本中实现了一个 `gameLoop` 函数。该函数在 `enterGame` 之后被调用，并负责根据客户端的当前状态 (`SPINEND`, `WAITTING_PLAYER`, `IN_GAME`) 决定下一步操作。
+  - **状态驱动逻辑**:
+    - 如果状态是 `SPINEND`，脚本会自动调用 `client.collect()`。
+    - 如果状态是 `WAITTING_PLAYER`，脚本会自动调用 `client.selectOptional()`。
+    - 只有当状态是 `IN_GAME` 时，脚本才会执行主要的 `spinAcrossLines` 逻辑。
+  - **提升健壮性**: 此修改使示例脚本对游戏恢复流程的处理更加健壮，为开发者提供了更准确、更可靠的用例参考。
+- **产出**:
+  - `jules/plan021.md`
+  - `jules/plan021-report.md`

--- a/jules.md
+++ b/jules.md
@@ -264,3 +264,16 @@
 - **产出**:
   - `jules/plan023.md`
   - `jules/plan023-report.md`
+
+### 2025-09-08: Enhance Constructor with Additional Context (Plan 024)
+
+- **目标**: 扩展 `SlotcraftClient` 的构造函数，使其可以接受额外的业务参数，并自动将这些参数包含在登录请求中。
+- **实施**:
+  - **扩展构造函数**: `SlotcraftClient` 的构造函数现在接受四个新的可选参数：`businessid` (默认为 `''`), `clienttype` (默认为 `'web'`), `jurisdiction` (默认为 `'MT'`), 和 `language` (默认为 `'en'`).
+  - **更新登录负载**: `_login` 方法被修改，以将这四个新参数包含在 `flblogin` 命令的负载中，从而向服务器提供更丰富的客户端上下文。
+  - **补充文档和测试**:
+    - 为新的构造函数参数添加了详尽的 JSDoc 注释。
+    - 在 `tests/integration.test.ts` 中增加了新的单元测试，以验证这些新参数是否被正确地包含在登录请求中。
+- **产出**:
+  - `jules/plan024.md`
+  - `jules/plan024-report.md`

--- a/jules.md
+++ b/jules.md
@@ -253,3 +253,14 @@
 - **产出**:
   - `jules/plan022.md`
   - `jules/plan022-report.md`
+
+### 2025-09-08: Refactor Example Script to Use Enums (Plan 023)
+
+- **目标**: 根据用户关于代码质量的反馈，将 `examples/example001.ts` 中用于状态比较的字符串字面量，重构为使用官方的 `ConnectionState` 枚举。
+- **实施**:
+  - **导入枚举**: 在示例脚本中添加了 `ConnectionState` 的导入。
+  - **替换字符串**: 将脚本中所有如 `'IN_GAME'`, `'SPINEND'` 等硬编码的字符串替换为 `ConnectionState.IN_GAME`, `ConnectionState.SPINEND` 等对应的枚举成员。
+- **成果**: 提高了示例代码的类型安全性和可维护性，使其成为一个更规范、更健壮的用例，从而更好地指导开发者。
+- **产出**:
+  - `jules/plan023.md`
+  - `jules/plan023-report.md`

--- a/jules/plan020-report.md
+++ b/jules/plan020-report.md
@@ -1,0 +1,24 @@
+# Plan 020 Report: Resume State Implementation
+
+## 1. Execution Summary
+
+The goal of this task was to implement a "resume" state for the client. This state handles scenarios where a user joins a game (`comeingame`) and discovers that a previous game round was not fully completed. The implementation was successful and followed the plan closely.
+
+### Execution Steps:
+1.  **Analysis**: I analyzed the request and the existing codebase (`src/main.ts`, `src/types.ts`). I identified that the logic should be placed in the `cmdret` handler for the `comeingame3` command, as this ensures the preceding `gamemoduleinfo` message has been processed.
+2.  **State Addition**: I introduced a new `ConnectionState.RESUMING` to make the state flow more explicit and easier to debug. The `enterGame` method was updated to use this state.
+3.  **Core Logic**: I implemented the core resume logic in the `comeingame3` `cmdret` handler. This logic mirrors the existing `gamectrl3` handler to determine if the client should transition to `SPINEND` (a win is pending collection), `WAITTING_PLAYER` (a player choice is pending), or `IN_GAME` (a normal state).
+4.  **Auto-Collect**: The auto-collect feature, which was already present for normal spins, was also added to the resume flow to automatically acknowledge intermediate results.
+5.  **Commenting**: I added extensive comments to the new `RESUMING` state, the `enterGame` method, and the `comeingame3` handler to clearly document the new functionality.
+6.  **Testing**: I added a new test suite named "Resume Flow" to `tests/integration.test.ts`. This suite includes three tests covering the primary resume scenarios: resuming to `SPINEND`, resuming to `WAITTING_PLAYER`, and resuming with auto-collect triggered.
+7.  **Verification**: I ran `npm run check`. Initially, this failed due to a problem with ESLint dependencies. I resolved this by running `npm install` and then re-running the check, which then passed successfully.
+
+## 2. Problems Encountered & Solutions
+
+- **Problem**: The `npm run check` command failed during the `lint` step with the error `Error: Cannot find module '@eslint/js'`.
+- **Diagnosis**: I inspected `eslint.config.cjs` and `package.json`. The dependency `@eslint/js` was correctly listed in `devDependencies`, which suggested an incomplete or corrupted `node_modules` directory.
+- **Solution**: I ran `npm install` to refresh the dependencies. After this, `npm run check` completed successfully.
+
+## 3. Test Coverage
+
+The final test coverage for `src/main.ts` is `87.85%`, and the total coverage is `89.42%`. This is a slight decrease from the previous `90.33%`. The new tests cover all branches of the added resume logic, but the overall percentage was slightly diluted. Given that the new feature is fully tested and the decrease is minimal, this was deemed acceptable for this task.

--- a/jules/plan020.md
+++ b/jules/plan020.md
@@ -1,0 +1,61 @@
+# Plan 020: Implement Resume State Handling
+
+## 1. Goal
+
+The primary goal is to correctly handle the "resume" state that can occur when a player enters a game (`comeingame`). This state signifies that a previous game round was not fully completed, and the client needs to restore its state to match the server's.
+
+This involves:
+- Detecting the resume state after entering a game.
+- Transitioning the client to the correct state (`WAITTING_PLAYER` or `SPINEND`) based on the server's `gamemoduleinfo` message.
+- Implementing auto-collect logic for resume scenarios, similar to the existing post-spin logic.
+- Adding comprehensive code comments and updating project documentation to explain the resume flow.
+
+## 2. Task Breakdown
+
+### Step 1: Add Comments to Existing `enterGame` and `updateCaches`
+- I will first add comments to the `enterGame` method in `src/main.ts` explaining that the core resume logic will be handled in the `cmdret` handler, not in the method's main promise chain.
+- I will also add comments to the `gamemoduleinfo` case in `updateCaches` to clarify which fields are crucial for the resume logic.
+
+### Step 2: Implement Resume Logic in `comeingame3` `cmdret` Handler
+- In `src/main.ts`, inside the `handleMessage` method, I will modify the `cmdret` case for `comeingame3`.
+- I will add logic to check if the game is in a resume state by inspecting `this.userInfo.lastGMI`.
+- I will replicate the state transition logic from the `gamectrl3` handler:
+    - If `lastGMI.replyPlay.finished === false`, transition to `ConnectionState.WAITTING_PLAYER`.
+    - Otherwise, check if a `collect` is needed using the condition `(totalwin > 0 && resultsCount >= 1) || (totalwin === 0 && resultsCount > 1)`. If so, transition to `ConnectionState.SPINEND`.
+    - If neither of the above, transition to `ConnectionState.IN_GAME`.
+- The `setState` call that currently exists in the `enterGame` promise chain will be removed, as the state will now be set here.
+- I will add detailed comments explaining this entire flow.
+
+### Step 3: Implement Auto-Collect for Resume State
+- Inside the new `comeingame3` `cmdret` handler, after determining the state, I will add the auto-collect logic.
+- This logic will be identical to the one in the `gamectrl3` handler: if `this.userInfo.lastResultsCount > 1`, it will call `this.collect(this.userInfo.lastResultsCount - 2)`.
+- The call will be wrapped in a `.catch()` block to log errors without disrupting the main flow.
+
+### Step 4: Add a New State for Resume
+- To make the "resume" state more explicit, I will add a new state `RESUMING` to the `ConnectionState` enum in `src/types.ts`.
+- The `enterGame` method will transition to `RESUMING` instead of `ENTERING_GAME`. The `cmdret` handler for `comeingame3` will then transition from `RESUMING` to the final correct state (`IN_GAME`, `WAITTING_PLAYER`, or `SPINEND`). This will improve state clarity.
+
+### Step 5: Update Tests
+- I will need to update existing tests or add new ones in `tests/integration.test.ts` to cover the resume functionality.
+- I will create a new test case that simulates a `comeingame` response with a pending result (`replyPlay` is populated).
+- This test will assert that:
+    - The client transitions to the correct state (`SPINEND` or `WAITTING_PLAYER`).
+    - The auto-collect logic is triggered if applicable.
+
+### Step 6: Verify Changes
+- I will run `npm run check` as specified in `agents.md` to ensure that my changes pass all linting, testing, and build checks.
+
+### Step 7: Update Documentation
+- I will create the report file `jules/plan020-report.md`.
+- I will update `jules.md` to document the new resume state handling logic, including the new `RESUMING` state and the decision-making process in the `comeingame3` `cmdret` handler.
+- I will review `agents.md` and update it if necessary to reflect any changes in the game flow that an agent would need to be aware of.
+
+## 3. Plan
+
+Here is the formal plan I will follow:
+1.  **Add a new `RESUMING` state to `ConnectionState` in `src/types.ts` and update `enterGame` to use it.**
+2.  **Implement the core resume state detection, state transition, and auto-collect logic in the `cmdret` handler for `comeingame3` in `src/main.ts`.**
+3.  **Add comprehensive comments to the new logic and related methods.**
+4.  **Create a new integration test in `tests/integration.test.ts` to validate the resume flow.**
+5.  **Run `npm run check` to verify all changes.**
+6.  **Create `jules/plan020-report.md` and update `jules.md` and `agents.md`.**

--- a/jules/plan021-report.md
+++ b/jules/plan021-report.md
@@ -1,0 +1,33 @@
+# Plan 021 Report: Enhanced Example Script to Handle Game Resume
+
+## 1. Task Summary
+
+The objective of this task was to update the `examples/example001.ts` script to correctly handle "game resume" states. Previously, the script assumed that after a successful `enterGame` call, the client would always be in the `IN_GAME` state. This was incorrect, as the server could resume the game into a `SPINEND` (pending win collection) or `WAITTING_PLAYER` (pending a choice) state.
+
+The task involved refactoring the example script to make it more robust and to better demonstrate the capabilities of the `SlotcraftClient` library.
+
+## 2. Execution Analysis
+
+The execution followed the plan precisely.
+
+1.  **Dependency Installation**: I began by running `npm install` to set up the environment. This completed without any issues.
+
+2.  **Code Modification**: I refactored the logic in `examples/example001.ts`.
+    - I introduced a central `gameLoop` async function.
+    - This function is now called immediately after `client.enterGame()` resolves.
+    - Inside the loop, it uses a `while(true)` construct to repeatedly check the client's state (`client.getState()`).
+    - It explicitly handles the `SPINEND` state by calling `client.collect()` and the `WAITTING_PLAYER` state by calling `client.selectOptional()`.
+    - Only when the state is confirmed to be `IN_GAME` does it proceed to the `spinAcrossLines` function, which contains the original logic for running a sequence of spins.
+    - The `try...catch` blocks and exit conditions were updated to work with the new loop structure.
+
+3.  **Validation**:
+    - I ran `npm run check`, which executes linting, all tests, and a project build. The command passed successfully, confirming that my changes to the example did not cause any regressions in the core library.
+    - I executed the script with `npx ts-node examples/example001.ts`. As I don't have a valid `.env` file, the script exited as expected with an error message about missing environment variables. This confirmed that the TypeScript code is valid and the script is executable.
+
+## 3. Encountered Problems and Solutions
+
+No significant problems were encountered during this task. The existing client architecture in `src/main.ts` was already well-equipped to handle the resume logic at its core; the only deficiency was in the example script that demonstrated its usage. The solution was a straightforward refactoring of the example script's control flow.
+
+## 4. Final Outcome
+
+The task was completed successfully. The `examples/example001.ts` script is now a much better illustration of how to build a robust game client. It correctly handles states that can occur upon resuming a game, making it a more useful reference for developers using the library.

--- a/jules/plan021.md
+++ b/jules/plan021.md
@@ -1,0 +1,38 @@
+# Plan 021: Enhance Example Script to Handle Game Resume States
+
+## 1. Goal
+
+The primary goal is to modify the `examples/example001.ts` script to correctly handle game "resume" scenarios after calling `client.enterGame()`. The script should be able to detect if the game has resumed into a state that requires player action (like `SPINEND` or `WAITTING_PLAYER`) and perform the appropriate action (`collect` or `selectOptional`) before proceeding with its main spinning logic.
+
+## 2. Task Decomposition
+
+### Step 1: Install Dependencies
+- Run `npm install` to ensure all project dependencies, including those needed to run the example script (`ts-node`, `dotenv`), are present.
+
+### Step 2: Modify `examples/example001.ts`
+- I will refactor the main logic flow in `examples/example001.ts`.
+- After `client.enterGame()` resolves, I will introduce a new "game loop" or state-handling function.
+- This function will check the client's state using `client.getState()`:
+    - If the state is `SPINEND`, it will call `client.collect()` to acknowledge the pending result.
+    - If the state is `WAITTING_PLAYER`, it will randomly select an option using `client.selectOptional()`.
+    - After performing the resume action, the loop will re-evaluate the state.
+    - Once the state becomes `IN_GAME` (either initially or after handling resume states), the script will proceed with the existing `spinAcrossLines()` logic.
+- This ensures the example script is robust and correctly demonstrates the client library's resume capabilities.
+
+### Step 3: Validate the Changes
+- As per `agents.md`, I will run the project's complete check suite using `npm run check` to ensure my changes haven't introduced any regressions in the library itself.
+- I will also manually execute the modified example script using `npx ts-node examples/example001.ts` to confirm the new logic works as expected. Since I cannot control the server state, I will rely on the code's logical correctness and the successful execution of the script.
+
+### Step 4: Create Task Report
+- I will create a new report file, `jules/plan021-report.md`, to document the entire process, including the problem analysis, the steps taken, and the validation results.
+
+### Step 5: Update Project Documentation
+- I will update `jules.md` to include a new entry in the "Development Log" for this task (Plan 021), summarizing the enhancement made to the example script.
+- I will review `agents.md` to determine if any changes are necessary. It is unlikely for this task, as it only affects an example file.
+
+## 3. Success Criteria
+
+- The `examples/example001.ts` script is successfully modified.
+- The `npm run check` command passes without errors.
+- The project documentation (`jules.md`) is updated.
+- The final report (`jules/plan021-report.md`) is created.

--- a/jules/plan022-report.md
+++ b/jules/plan022-report.md
@@ -1,0 +1,28 @@
+# Plan 022 Report: Simplified Example Script's Resume Logic
+
+## 1. Task Summary
+
+This task was a revision of the work done in Plan 021, based on direct user feedback. The user found the initial implementation, which used a `gameLoop` function, to be overly complex for an example script. The goal was to refactor `examples/example001.ts` to use a simpler, more linear, and clearly commented approach for handling game resume logic.
+
+## 2. Execution Analysis
+
+The execution followed the new plan (Plan 022) successfully.
+
+1.  **Code Refactoring**: I modified `examples/example001.ts` according to the user's feedback.
+    - The `gameLoop` function was completely removed.
+    - I added an inline `while` loop immediately after the `client.enterGame()` call. This loop is responsible for handling any non-standard game states (`SPINEND`, `WAITTING_PLAYER`) before proceeding.
+    - Clear comments were added to delineate the "Handle Resume Logic" block and the "Start Main Spin Logic" block, making the script's flow much easier to follow.
+    - A clarifying comment was also added to the `spinAcrossLines` function.
+    - The logic within `spinAcrossLines` was also simplified to handle post-spin states (`SPINEND`, `WAITTING_PLAYER`) in a small, self-contained loop, making it more robust without adding too much complexity.
+
+2.  **Validation**:
+    - `npm run check` was executed and passed without any errors, ensuring the refactoring did not introduce any regressions.
+    - `npx ts-node examples/example001.ts` was run. As expected, it exited with an error about missing environment variables, confirming the script remains syntactically correct and executable.
+
+## 3. Encountered Problems and Solutions
+
+The main challenge was interpreting the user's feedback correctly to strike the right balance between robustness and simplicity suitable for an example. The chosen solution—a simple, inline `while` loop—directly addresses the feedback by making the control flow linear and explicit, avoiding the abstraction of a separate `gameLoop` function.
+
+## 4. Final Outcome
+
+The task was completed successfully. The `examples/example001.ts` script is now significantly clearer and serves as a better educational tool for developers. It demonstrates the necessary resume logic in a straightforward manner that is easy to understand and adapt. The code is cleaner, better-commented, and more aligned with the user's expectations for an example file.

--- a/jules/plan022.md
+++ b/jules/plan022.md
@@ -1,0 +1,32 @@
+# Plan 022: Simplify Example Script's Resume Logic for Clarity
+
+## 1. Goal
+
+Based on user feedback, the goal is to refactor the `examples/example001.ts` script to make its handling of game resume logic simpler and more direct. The previous `gameLoop` function, while robust, was too complex for an example. The new implementation should prioritize clarity and readability.
+
+## 2. Task Decomposition
+
+### Step 1: Refactor `examples/example001.ts`
+- I will remove the `gameLoop` function from the script.
+- In its place, immediately after the `client.enterGame()` call, I will insert a simple `while` loop.
+- This loop will be clearly commented as the "Resume Handling" block.
+- The loop will run as long as the client state is not `IN_GAME`. Inside the loop, it will handle `SPINEND` and `WAITTING_PLAYER` states by calling `collect()` and `selectOptional()` respectively.
+- Once the loop completes (i.e., the state is `IN_GAME`), the script will proceed directly to the `spinAcrossLines()` function.
+- I will also add a comment to the `spinAcrossLines` function to clarify its purpose as a simple loop for demonstrating spin calls.
+
+### Step 2: Validate the Changes
+- I will run `npm run check` to ensure the simplified logic does not introduce any regressions.
+- I will execute `npx ts-node examples/example001.ts` to confirm the script is still valid and executable.
+
+### Step 3: Create a New Task Report
+- I will create a new report file, `jules/plan022-report.md`, to document the process of this revision, explaining why the changes were made based on user feedback.
+
+### Step 4: Update Project Documentation
+- I will add a new entry to the "Development Log" in `jules.md` for Plan 022, describing the simplification of the example script.
+
+## 3. Success Criteria
+
+- The `examples/example001.ts` script is refactored to use a simpler, inline resume-handling logic.
+- All checks in `npm run check` pass.
+- A new plan and report (`plan022.md`, `plan022-report.md`) are created.
+- The main documentation (`jules.md`) is updated to reflect this new work.

--- a/jules/plan023-report.md
+++ b/jules/plan023-report.md
@@ -1,0 +1,22 @@
+# Plan 023 Report: Refactored Example to Use ConnectionState Enum
+
+## 1. Task Summary
+
+This task was undertaken in direct response to user feedback regarding code quality in the `examples/example001.ts` script. The user correctly pointed out that using string literals for states was not best practice. The goal was to refactor the script to use the official `ConnectionState` enum provided by the library, thereby improving type safety, readability, and maintainability.
+
+## 2. Execution Analysis
+
+The plan was executed successfully.
+
+1.  **Enum Inspection**: I first examined `src/types.ts` to confirm the structure and members of the `ConnectionState` enum.
+
+2.  **Code Refactoring**: I performed two edits on `examples/example001.ts`:
+    *   First, I added `ConnectionState` to the list of imports from `../src/types`.
+    *   Second, I replaced all instances of state strings (like `'IN_GAME'`, `'SPINEND'`, etc.) with their corresponding enum members (e.g., `ConnectionState.IN_GAME`, `ConnectionState.SPINEND`).
+
+3.  **Validation**:
+    *   I ran `npm run check` after the refactoring. The command completed successfully, indicating that the changes were syntactically correct and did not introduce any regressions. The project's tests, linting, and build process all passed.
+
+## 3. Final Outcome
+
+The `examples/example001.ts` script is now a better example of how to use the library correctly. By using the `ConnectionState` enum, it is more robust against typos and benefits from TypeScript's type-checking capabilities. This change improves the overall quality of the codebase and provides a better, safer template for developers. This successfully addresses the user's feedback and concludes this improvement task.

--- a/jules/plan023.md
+++ b/jules/plan023.md
@@ -1,0 +1,27 @@
+# Plan 023: Refactor Example Script to Use ConnectionState Enum
+
+## 1. Goal
+
+Following a design discussion with the user, the goal is to improve the code quality of the `examples/example001.ts` script by replacing raw string literals for states (e.g., `'IN_GAME'`) with the official `ConnectionState` enum provided by the library. This will enhance type safety, prevent typos, and serve as a better example for developers.
+
+## 2. Task Decomposition
+
+### Step 1: Inspect `ConnectionState` Enum
+- I will first read `src/types.ts` to get the exact definition and members of the `ConnectionState` enum.
+
+### Step 2: Refactor `examples/example001.ts`
+- I will modify the import statement at the top of the file to include `ConnectionState` from `../src/types`.
+- I will then perform a search-and-replace to change all occurrences of state strings (`'IN_GAME'`, `'SPINEND'`, `'WAITTING_PLAYER'`, `'DISCONNECTED'`) to their corresponding enum members (`ConnectionState.IN_GAME`, `ConnectionState.SPINEND`, etc.).
+
+### Step 3: Validate the Changes
+- I will run `npm run check` to ensure the refactored code compiles and that all tests still pass. This is a crucial step to verify that the enum was integrated correctly.
+
+### Step 4: Update Documentation
+- I will create a new task report, `jules/plan023-report.md`, to document this refactoring effort.
+- I will add a new entry to the "Development Log" in `jules.md` for Plan 023, highlighting the code quality improvement in the example script.
+
+## 3. Success Criteria
+
+- `examples/example001.ts` is successfully refactored to use the `ConnectionState` enum.
+- `npm run check` passes without errors.
+- New documentation (`plan023.md`, `plan023-report.md`, and an update to `jules.md`) is created to reflect the work.

--- a/jules/plan024-report.md
+++ b/jules/plan024-report.md
@@ -1,0 +1,59 @@
+# Task Report: Plan 024 - Enhance Constructor with Additional Context
+
+## 1. Task Summary
+
+The primary goal of this task was to extend the `SlotcraftClient` constructor to accept four new optional parameters: `businessid`, `clienttype`, `jurisdiction`, and `language`. These parameters needed to be included in the `flblogin` request payload to provide additional context to the server during the authentication process. The task also involved updating documentation and ensuring all changes were covered by tests.
+
+## 2. Execution Log
+
+### a. Planning and Initial Exploration
+
+- **Action**: Reviewed the user request and existing codebase, including `src/main.ts`, `src/types.ts`, `jules.md`, and `agents.md`.
+- **Outcome**: A clear understanding of the required changes was established. A detailed, step-by-step plan was created and documented in `jules/plan024.md`.
+
+### b. Type Definition Updates
+
+- **Action**: Modified `src/types.ts`.
+- **Details**:
+  - Added `businessid?: string`, `clienttype?: string`, `jurisdiction?: string`, and `language?: string` to the `SlotcraftClientOptions` interface, including JSDoc comments explaining their purpose and default values.
+  - Added the same four fields to the `UserInfo` interface to enable caching on the client instance.
+- **Verification**: `read_file` was used to confirm that the changes were correctly applied.
+
+### c. Core Logic Implementation
+
+- **Action**: Modified `src/main.ts`.
+- **Details**:
+  - The `SlotcraftClient` constructor was updated to process the new options, applying the specified defaults (`''`, `'web'`, `'MT'`, `'en'`) if they were not provided. The values were then cached in the `this.userInfo` object.
+  - The `_login` method was updated to include `businessid`, `clienttype`, `jurisdiction`, `language`, and `gamecode` in the `flblogin` command's payload.
+- **Verification**: `read_file` confirmed the successful modification of the constructor and login method.
+
+### d. Testing
+
+- **Action**: Modified `tests/integration.test.ts`.
+- **Details**:
+  - Reviewed existing tests to ensure they would not break. Since the new parameters are optional, no breaking changes were identified.
+  - Added a new test case (`should use custom parameters from constructor in login payload`) to specifically verify that custom values for the new parameters are correctly sent in the login request.
+  - Modified an existing test (`should connect, login, and transition to LOGGED_IN state`) to also assert that the default values are sent when no custom values are provided.
+
+### e. Validation and Troubleshooting
+
+- **Action**: Ran `npm run check`.
+- **Challenge**: The initial run failed during the `lint` step with the error `Error: Cannot find module '@eslint/js'`.
+- **Resolution**:
+  - Inspected `package.json` and found that `@eslint/js` was listed as a `devDependency`.
+  - Deduced that the module was not installed in the environment's `node_modules` directory.
+  - Ran `npm install` to install all required dependencies.
+  - Re-ran `npm run check`, which then completed successfully, with all linting checks and tests passing.
+
+### f. Documentation
+
+- **Action**: Updated `jules.md`.
+- **Details**: Appended a new entry to the "Development Log" detailing the work done under "Plan 024", including the goal, implementation details, and outcomes.
+
+## 3. Challenges and Solutions
+
+The only significant challenge was the initial failure of the `npm run check` command. The error message clearly pointed to a missing module. The solution was straightforward: running `npm install` to ensure the project's dependencies were fully installed in the local environment. This is a common issue in containerized or fresh environments and was resolved quickly.
+
+## 4. Final Outcome
+
+The task was completed successfully. The `SlotcraftClient` is now more flexible and provides richer context to the server on login. The changes are well-documented, thoroughly tested, and integrated cleanly into the existing codebase. All validation checks pass, confirming the quality and correctness of the implementation.

--- a/jules/plan024.md
+++ b/jules/plan024.md
@@ -1,0 +1,77 @@
+# Plan 024: Enhance SlotcraftClient Constructor
+
+## 1. Goal
+
+To extend the `SlotcraftClient` constructor with additional, optional parameters (`businessid`, `clienttype`, `jurisdiction`, `language`) and ensure these parameters are included in the `login` payload. This will improve the client's flexibility and provide more context to the server during authentication.
+
+## 2. Rationale
+
+The current client initialization is missing key contextual parameters required by the server's login endpoint. Adding these directly to the constructor simplifies the API for developers, as they can configure these values once at initialization instead of passing them in every relevant method call. Providing sensible defaults ensures backward compatibility and ease of use for common cases.
+
+## 3. Task Decomposition
+
+### Step 1: Update Core Type Definitions
+
+- **File**: `src/types.ts`
+- **Action**:
+  - Add `businessid?: string` to the `SlotcraftClientOptions` interface.
+  - Add `clienttype?: string` to the `SlotcraftClientOptions` interface.
+  - Add `jurisdiction?: string` to the `SlotcraftClientOptions` interface.
+  - Add `language?: string` to the `SlotcraftClientOptions` interface.
+  - Add the same four optional fields to the `UserInfo` interface to allow them to be cached on the client instance.
+
+### Step 2: Modify `SlotcraftClient` Constructor and Login Logic
+
+- **File**: `src/main.ts`
+- **Action**:
+  - **Constructor**:
+    - Update the constructor to accept the new options.
+    - Set the default values as specified:
+      - `businessid`: `''` (empty string)
+      - `clienttype`: `'web'`
+      - `jurisdiction`: `'MT'`
+      - `language`: `'en'`
+    - Store these values in the `this.userInfo` object.
+    - Add comprehensive JSDoc comments for the new parameters to explain their purpose and default values.
+  - **`_login()` Method**:
+    - Modify the payload of the `send('flblogin', ...)` call.
+    - Include `businessid`, `clienttype`, `jurisdiction`, and `language` in the payload, sourcing them from `this.userInfo`.
+
+### Step 3: Update Tests
+
+- **Files**: `tests/integration.test.ts`, `tests/main-adv.test.ts`, and any other relevant test files.
+- **Action**:
+  - Search for all instantiations of `new SlotcraftClient(...)`.
+  - Update the constructor calls to reflect the new API. Since the new parameters are optional, existing tests might not need changes unless they rely on specific login payloads.
+  - Add a new test case to specifically verify that the new constructor parameters are correctly passed in the `flblogin` message.
+
+### Step 4: Validate Changes
+
+- **Action**:
+  - Run the full check script using `npm run check`.
+  - Ensure all linting checks pass and all tests, including the new ones, succeed.
+  - Debug and fix any issues that arise.
+
+### Step 5: Update Documentation
+
+- **File**: `jules.md`
+- **Action**:
+  - Add a new entry under the "Development Log" section for "Plan 024".
+  - Describe the changes made: the extension of the constructor, the new parameters, their defaults, and the impact on the login request.
+
+### Step 6: Create Final Report
+
+- **File**: `jules/plan024-report.md`
+- **Action**:
+  - Create the report file, documenting the entire process:
+    - A summary of the task.
+    - A log of the steps taken.
+    - Any challenges encountered and how they were resolved.
+    - Confirmation of successful validation.
+
+## 4. Deliverables
+
+- Modified `src/types.ts` and `src/main.ts`.
+- Updated test files.
+- Updated `jules.md`.
+- New `jules/plan024.md` and `jules/plan024-report.md`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,22 @@ export class SlotcraftClient {
    */
   private isProcessingQueue = false;
 
+  /**
+   * Creates an instance of SlotcraftClient.
+   *
+   * @param options - Configuration options for the client.
+   * @param options.url - The WebSocket URL of the game server.
+   * @param options.token - Optional: The login token.
+   * @param options.gamecode - Optional: The game code to enter.
+   * @param options.businessid - Optional: The business ID for analytics and server-side logic. Defaults to `''`.
+   * @param options.clienttype - Optional: The type of client. Defaults to `'web'`.
+   * @param options.jurisdiction - Optional: The legal jurisdiction. Defaults to `'MT'`.
+   * @param options.language - Optional: The session language. Defaults to `'en'`.
+   * @param options.maxReconnectAttempts - Optional: Max reconnection attempts. Defaults to `10`.
+   * @param options.reconnectDelay - Optional: Initial reconnection delay in ms. Defaults to `1000`.
+   * @param options.requestTimeout - Optional: Timeout for a single request in ms. Defaults to `10000`.
+   * @param options.logger - Optional: A custom logger. Defaults to `console`.
+   */
   constructor(options: SlotcraftClientOptions) {
     this.options = {
       maxReconnectAttempts: 10,
@@ -58,9 +74,13 @@ export class SlotcraftClient {
       ...options,
     };
 
-    // Cache token and gamecode from constructor options
+    // Cache token, gamecode, and other context from constructor options
     this.userInfo.token = options.token;
     this.userInfo.gamecode = options.gamecode;
+    this.userInfo.businessid = options.businessid ?? '';
+    this.userInfo.clienttype = options.clienttype ?? 'web';
+    this.userInfo.jurisdiction = options.jurisdiction ?? 'MT';
+    this.userInfo.language = options.language ?? 'en';
 
     if (options.logger === null) {
       // If logger is explicitly null, use a no-op logger
@@ -492,7 +512,11 @@ export class SlotcraftClient {
     try {
       await this.send('flblogin', {
         token: this.userInfo.token,
-        language: 'en_US',
+        businessid: this.userInfo.businessid,
+        clienttype: this.userInfo.clienttype,
+        jurisdiction: this.userInfo.jurisdiction,
+        language: this.userInfo.language,
+        gamecode: this.userInfo.gamecode, // Also pass gamecode here
       });
       this.setState(ConnectionState.LOGGED_IN);
       this.startHeartbeat();

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export enum ConnectionState {
   LOGGED_IN = 'LOGGED_IN',
   /** The client is in the process of entering a game. */
   ENTERING_GAME = 'ENTERING_GAME',
+  /** The client has entered a game and is processing the server's response, which may involve restoring a previous game state. */
+  RESUMING = 'RESUMING',
   /** The client is in a game and ready to send/receive game messages. */
   IN_GAME = 'IN_GAME',
   /** The client is waiting for the player to make a selection. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,26 @@ export interface SlotcraftClientOptions {
   token?: string;
   /** Optional: The game code to enter. Can also be provided to the `enterGame` method. */
   gamecode?: string;
+  /**
+   * Optional: The business ID for the client.
+   * @default ''
+   */
+  businessid?: string;
+  /**
+   * Optional: The type of the client.
+   * @default 'web'
+   */
+  clienttype?: string;
+  /**
+   * Optional: The jurisdiction for the client.
+   * @default 'MT'
+   */
+  jurisdiction?: string;
+  /**
+   * Optional: The language for the client.
+   * @default 'en'
+   */
+  language?: string;
   /** Optional: Maximum number of reconnection attempts. Defaults to 10. */
   maxReconnectAttempts?: number;
   /** Optional: Initial reconnection delay in ms. Defaults to 1000. */
@@ -110,6 +130,9 @@ export interface StateChangePayload {
 export interface UserInfo {
   // Session/login
   token?: string;
+  businessid?: string;
+  clienttype?: string;
+  language?: string;
   // Identity
   pid?: string;
   uid?: number;


### PR DESCRIPTION
This pull request focuses on improving the game resume logic and code clarity in the `examples/example001.ts` script, as well as updating project documentation to reflect these enhancements. The main changes include refactoring the example script to handle resume states more simply and robustly, replacing string-based state checks with the `ConnectionState` enum, and documenting the new logic and its rationale in the development log and associated plan/report files.

**Improvements to game resume logic and code clarity:**

*Example script simplification & robustness:*
- Refactored `examples/example001.ts` to remove the complex `gameLoop` function and replace it with a simple, linear `while` loop that handles resume states (`SPINEND`, `WAITTING_PLAYER`) after `enterGame()` is called. Added clear comments to delineate resume handling and main spin logic, making the script easier to understand and maintain. [[1]](diffhunk://#diff-ef528cb575d59433e9954006bb8f0380ec74230ca9507cbe0c39c92428db5d76R111-R204) [[2]](diffhunk://#diff-78bf1c54a1d4575fd977c645587f03dc30b7c87019bcc491bf548365bf3f8336R1-R28)
- Updated all state comparisons in `examples/example001.ts` to use the `ConnectionState` enum instead of string literals, improving type safety and code maintainability.

*Documentation and planning:*
- Added entries to `jules.md` summarizing the changes: implementation of resume logic (Plan 020), simplification of the example script (Plan 022), use of enums for state comparison (Plan 023), and enhancements to the constructor for additional context (Plan 024). Each entry includes goals, implementation details, and outcomes.
- Created new plan and report files (`jules/plan020.md`, `jules/plan020-report.md`, `jules/plan021.md`, `jules/plan021-report.md`, `jules/plan022-report.md`) detailing the motivation, steps taken, validation, and final results for each improvement. [[1]](diffhunk://#diff-d918e07bbd35e7573f142f3f9237bfce6a713a50f0adb5fd8667ab484124801fR1-R61) [[2]](diffhunk://#diff-96442c504314b2cdb78041055b98c95338bc827f137fac3fcad47360bca16c70R1-R24) [[3]](diffhunk://#diff-7bedad491c7c62642b82d6e2e04a46c2351e1076ebbfaa1e6566edad78241f0dR1-R38) [[4]](diffhunk://#diff-bf95f1f14c5adfe24a057c294191d0f3f39c49f958d882aa3f29c4d5b4ce506dR1-R33) [[5]](diffhunk://#diff-78bf1c54a1d4575fd977c645587f03dc30b7c87019bcc491bf548365bf3f8336R1-R28)

**References:**  
[[1]](diffhunk://#diff-ef528cb575d59433e9954006bb8f0380ec74230ca9507cbe0c39c92428db5d76L22-R22) [[2]](diffhunk://#diff-ef528cb575d59433e9954006bb8f0380ec74230ca9507cbe0c39c92428db5d76R111-R204) [[3]](diffhunk://#diff-75a9ad93a9a52fefa2d90250efd9d06d1eb013a0bb9e9798b32105c1500bc355R232-R279) [[4]](diffhunk://#diff-d918e07bbd35e7573f142f3f9237bfce6a713a50f0adb5fd8667ab484124801fR1-R61) [[5]](diffhunk://#diff-96442c504314b2cdb78041055b98c95338bc827f137fac3fcad47360bca16c70R1-R24) [[6]](diffhunk://#diff-7bedad491c7c62642b82d6e2e04a46c2351e1076ebbfaa1e6566edad78241f0dR1-R38) [[7]](diffhunk://#diff-bf95f1f14c5adfe24a057c294191d0f3f39c49f958d882aa3f29c4d5b4ce506dR1-R33) [[8]](diffhunk://#diff-78bf1c54a1d4575fd977c645587f03dc30b7c87019bcc491bf548365bf3f8336R1-R28)