### PR TITLE
feat: Cache defaultScene and add transformation utility

### DIFF
--- a/jules.md
+++ b/jules.md
@@ -313,3 +313,12 @@
 - **产出**:
   - `jules/plan027.md`
   - `jules/plan027-report.md`
+
+## 9. Utilities
+
+### `transformSceneData(data)`
+
+- **Source**: `src/utils.ts`
+- **Description**: A utility function designed to simplify the complex `defaultScene` object received from the server into a more usable format.
+- **Input**: Takes a raw scene data object, which typically has a structure like `{ values: [{ values: [1, 2] }, ...] }`.
+- **Output**: Returns a simple 2D array of numbers (e.g., `[[1, 2], ...]`). This flattened structure is easier to work with in the game logic. The function is robust and handles malformed or empty inputs by returning an empty array.

--- a/jules/plan028-report.md
+++ b/jules/plan028-report.md
@@ -1,0 +1,32 @@
+# Report for Plan 028: Cache defaultScene from gamemoduleinfo
+
+## 1. Task Execution Summary
+
+The goal was to cache the `defaultScene` data from `gamemoduleinfo` messages, transform it into a 2D array, and make the transformation logic a reusable, tested, and documented utility function. The execution followed the plan precisely.
+
+1.  **Utility Function**: Created `src/utils.ts` and implemented the `transformSceneData` function with JSDoc comments.
+2.  **Unit Tests**: Created `tests/utils.test.ts` with comprehensive tests covering the happy path and various edge cases (null input, malformed data, empty arrays).
+3.  **Type Definition**: Updated the `UserInfo` interface in `src/types.ts` to include the new `defaultScene?: number[][]` property.
+4.  **Integration**: Modified the `updateCaches` method in `src/main.ts` to use the new `transformSceneData` function and populate `this.userInfo.defaultScene` when a `gamemoduleinfo` message with `defaultScene` is received.
+5.  **Export**: Exported `transformSceneData` from the library's main entry point, `src/index.ts`.
+6.  **Verification**: Ran `npm run check`, which passed successfully after fixing an environment issue.
+7.  **Documentation**: Updated `jules.md` with a new "Utilities" section documenting the `transformSceneData` function.
+
+## 2. Problems Encountered and Solutions
+
+### Problem: ESLint Command Failure
+
+- **Symptom**: The `npm run check` command failed at the `npm run lint` step with the error: `Error: Cannot find module '@eslint/js'`.
+- **Diagnosis**: This error typically means a required npm package is not installed in the `node_modules` directory. I first checked `package.json` and confirmed that `@eslint/js` was indeed listed as a `devDependency`. This suggested that the `node_modules` directory was out of sync with the `package.json` file.
+- **Solution**: I ran `npm install` to refresh the dependencies and install any missing packages. After the installation completed successfully, I re-ran `npm run check`, and all steps (lint, test, build) passed without any issues.
+
+## 3. Final Code Review
+
+The changes are clean and self-contained.
+- The new utility function is pure, well-documented, and thoroughly tested.
+- The integration into `main.ts` is minimal and safe, checking for the existence of `defaultScene` before processing.
+- The types are updated correctly.
+- The public API is extended by exporting the new utility.
+- The project documentation is updated.
+
+The solution successfully meets all requirements of the original task.

--- a/jules/plan028.md
+++ b/jules/plan028.md
@@ -1,0 +1,52 @@
+# Plan 028: Cache defaultScene from gamemoduleinfo
+
+## 1. Understanding the Goal
+
+The user wants to cache the `defaultScene` data received in the `gamemoduleinfo` message. This data needs to be transformed from a complex object structure into a simple 2D array and stored in the `UserInfo` object. The transformation logic must be an exported utility function with its own tests and documentation.
+
+## 2. Task Decomposition
+
+### Step 1: Create a Utility Function for Data Transformation
+- Create a new file: `src/utils.ts`.
+- Inside this file, implement an exported function named `transformSceneData`.
+- This function will accept an object argument matching the structure of `defaultScene` (i.e., `{ values: [{ values: [...] }] }`).
+- It will return a 2D array of numbers (`number[][]`).
+- Add comprehensive JSDoc comments explaining what the function does, its parameters, and what it returns.
+
+### Step 2: Write Unit Tests for the Utility Function
+- Create a new test file: `tests/utils.test.ts`.
+- Write test cases for `transformSceneData`.
+- Test the happy path with the example data provided in the task description.
+- Test edge cases, such as:
+  - An empty outer `values` array.
+  - An inner `values` array being empty.
+  - Malformed input (e.g., missing `values` properties).
+  - Input being `null` or `undefined`.
+
+### Step 3: Update Core Types
+- Open `src/types.ts`.
+- Add a new optional property `defaultScene?: number[][]` to the `UserInfo` interface.
+
+### Step 4: Integrate the Transformation Logic into the Message Handler
+- Open `src/main.ts`.
+- Import the `transformSceneData` function from `./utils`.
+- Locate the `updateCaches` method and the `case 'gamemoduleinfo':` block.
+- Inside this block, check if `g.defaultScene` exists.
+- If it does, call `transformSceneData(g.defaultScene)` and assign the result to `this.userInfo.defaultScene`.
+
+### Step 5: Export the New Utility
+- Open `src/index.ts`.
+- Export the `transformSceneData` function from `./utils` to make it accessible to external consumers of the library.
+
+### Step 6: Verify the Changes
+- Run the full check script: `npm run check`.
+- This will execute linting, all tests (including the new ones), and the build process.
+- Ensure all checks pass without errors.
+
+### Step 7: Update Documentation
+- Update the main project documentation file, `jules.md`.
+- Add a new section, e.g., "## Utilities", to document the `transformSceneData` function. Describe its purpose and usage.
+
+## 3. Post-Execution
+- After completing the task, create a report file `jules/plan028-report.md` detailing the execution process, challenges, and solutions.
+- Review and update `agents.md` if the changes are relevant for future AI agent work (in this case, it's unlikely to be necessary, but should be checked).

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@
 
 export { SlotcraftClient } from './main';
 export * from './types';
+export * from './utils';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { transformSceneData } from './utils';
 import { Connection } from './connection';
 import { EventEmitter } from './event-emitter';
 import {
@@ -767,6 +768,11 @@ export class SlotcraftClient {
               };
             }
           }
+        }
+
+        // Cache the default scene if it exists, transforming it into a 2D array.
+        if (g.defaultScene) {
+          this.userInfo.defaultScene = transformSceneData(g.defaultScene);
         }
         break;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,8 @@ export interface UserInfo {
   // Player choice context
   optionals?: Optional[];
   curSpinParams?: SpinParams;
+  // Scene data, simplified into a 2D array
+  defaultScene?: number[][];
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Utility functions for the project.
+ */
+
+/**
+ * Represents the complex structure of scene data received from the server.
+ */
+interface RawSceneData {
+  values: Array<{
+    values: number[];
+  }>;
+  // The object can have other properties that we ignore.
+  [key: string]: any;
+}
+
+/**
+ * Transforms a raw scene data object from the server into a simple 2D array.
+ *
+ * The function expects an object with a `values` property, which is an array of objects.
+ * Each of these nested objects should also have a `values` property containing an array of numbers.
+ *
+ * Example Input:
+ * ```json
+ * {
+ *   "values": [
+ *     { "values": [4, 8, 2, 3] },
+ *     { "values": [2, 2, 2, 2] }
+ *   ]
+ * }
+ * ```
+ *
+ * Example Output:
+ * ```json
+ * [
+ *   [4, 8, 2, 3],
+ *   [2, 2, 2, 2]
+ * ]
+ * ```
+ *
+ * @param data - The raw scene data object. Can be null or undefined.
+ * @returns A 2D array of numbers, or an empty array if the input is invalid or empty.
+ */
+export function transformSceneData(data: RawSceneData | null | undefined): number[][] {
+  if (!data || !Array.isArray(data.values)) {
+    return [];
+  }
+
+  return data.values.map((row) => (row && Array.isArray(row.values) ? row.values : []));
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { transformSceneData } from '../src/utils';
+
+describe('transformSceneData', () => {
+  it('should transform valid scene data into a 2D array', () => {
+    const sceneData = {
+      values: [
+        { values: [4, 8, 2, 3] },
+        { values: [2, 2, 2, 2] },
+        { values: [8, 3, 5, 7] },
+        { values: [8, 5, 2, 2] },
+        { values: [1, 8, 6, 5] },
+      ],
+      indexes: [],
+      validRow: [],
+    };
+    const expected = [
+      [4, 8, 2, 3],
+      [2, 2, 2, 2],
+      [8, 3, 5, 7],
+      [8, 5, 2, 2],
+      [1, 8, 6, 5],
+    ];
+    expect(transformSceneData(sceneData)).toEqual(expected);
+  });
+
+  it('should return an empty array if the input is null or undefined', () => {
+    expect(transformSceneData(null)).toEqual([]);
+    expect(transformSceneData(undefined)).toEqual([]);
+  });
+
+  it('should return an empty array if the top-level values property is not an array', () => {
+    const sceneData = { values: 'not-an-array' } as any;
+    expect(transformSceneData(sceneData)).toEqual([]);
+  });
+
+  it('should handle an empty top-level values array', () => {
+    const sceneData = { values: [] };
+    expect(transformSceneData(sceneData)).toEqual([]);
+  });
+
+  it('should handle rows where the nested values property is missing or not an array', () => {
+    const sceneData = {
+      values: [
+        { values: [1, 2] },
+        {} as any, // Missing nested 'values'
+        { values: 'not-an-array' } as any,
+        { values: [3, 4] },
+      ],
+    };
+    const expected = [[1, 2], [], [], [3, 4]];
+    expect(transformSceneData(sceneData)).toEqual(expected);
+  });
+
+  it('should handle rows with empty nested values arrays', () => {
+    const sceneData = {
+      values: [{ values: [1, 2] }, { values: [] }, { values: [3, 4] }],
+    };
+    const expected = [[1, 2], [], [3, 4]];
+    expect(transformSceneData(sceneData)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
- Adds a new utility function `transformSceneData` to convert the complex `defaultScene` object from the server into a simple 2D array.
- Implements unit tests for the new utility function, covering various edge cases.
- Updates the `UserInfo` type to include the `defaultScene` as `number[][]`.
- Integrates the function into the `gamemoduleinfo` message handler to cache the transformed data.
- Exports the new utility function for public use.
- Updates `jules.md` to document the new function.